### PR TITLE
.github: refactor github actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - develop
     tags: 'REL-*'
 
@@ -11,25 +11,16 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ["Debug", "Release"]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build projects
-        run: make
-      - name: Build projects for release
-        if: >-
-          github.event_name == 'push' &&
-          startsWith(github.event.ref, 'refs/tags')
-        run: BUILD_CONFIG=Release make
-      - name: Convert 02drv_triangle elf to hex
-        if: >-
-          github.event_name == 'push' &&
-          startsWith(github.event.ref, 'refs/tags')
-        run: >-
-          objcopy -O ihex
-          02drv_triangle/Output/Debug/Exe/02drv_triangle.elf
-          02drv_triangle/Output/Debug/Exe/02drv_triangle.hex
+        run: BUILD_CONFIG=${{ matrix.config }} make docker
       - name: Release
         uses: ncipollo/release-action@v1
         if: >-
@@ -37,7 +28,4 @@ jobs:
           startsWith(github.event.ref, 'refs/tags')
         with:
           generateReleaseNotes: true
-          artifacts: "
-            02drv_triangle/Output/Debug/Exe/02drv_triangle.elf
-            02drv_triangle/Output/Debug/Exe/02drv_triangle.hex"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/02drv_ntw/02drv_ntw.c
+++ b/02drv_ntw/02drv_ntw.c
@@ -44,7 +44,7 @@ int main(void) {
     board_init();
 
     // ntw
-    ntw_init(_ntw_receive_cb);
+    ntw_init(NULL, NULL, _ntw_receive_cb);
 
     // initialize the periodic timer
     periodictimer_init(

--- a/03app_expo_corridor/03app_expo_corridor.c
+++ b/03app_expo_corridor/03app_expo_corridor.c
@@ -44,7 +44,7 @@ int main(void) {
     board_init();
 
     // ntw
-    ntw_init(_ntw_receive_cb);
+    ntw_init(NULL, NULL, _ntw_receive_cb);
 
     // initialize the periodic timer
     periodictimer_init(

--- a/03app_expo_hall/03app_expo_hall.c
+++ b/03app_expo_hall/03app_expo_hall.c
@@ -44,7 +44,7 @@ int main(void) {
     board_init();
 
     // ntw
-    ntw_init(_ntw_receive_cb);
+    ntw_init(NULL, NULL, _ntw_receive_cb);
 
     // initialize the periodic timer
     periodictimer_init(

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,23 @@
 .PHONY: all list-projects
 
+DOCKER_IMAGE ?= aabadie/dotbot:latest
+DOCKER_TARGETS ?= all
 SEGGER_DIR ?= /opt/segger
 BUILD_CONFIG ?= Debug
 SEGGER_PROJECT ?= aiot_play_fw.emProject
 
-PROJECTS ?= 02drv_triangle
-
-.PHONY: $(PROJECTS)
-
-all: $(PROJECTS)
-
-$(PROJECTS):
-	@echo "\e[1mBuilding project $@\e[0m"
-	"$(SEGGER_DIR)/bin/emBuild" $(SEGGER_PROJECT) -project $@ -config $(BUILD_CONFIG) -rebuild -verbose
+all:
+	@echo "\e[1mBuilding all projects\e[0m"
+	"$(SEGGER_DIR)/bin/emBuild" $(SEGGER_PROJECT) -config $(BUILD_CONFIG) -rebuild -verbose
 	@echo "\e[1mDone\e[0m\n"
-
-list-projects:
-	@echo "\e[1mAvailable projects:\e[0m"
-	@echo $(PROJECTS) | tr ' ' '\n'
 
 clean:
 	"$(SEGGER_DIR)/bin/emBuild" $(SEGGER_PROJECT) -config $(BUILD_CONFIG) -clean
 
+docker:
+	docker run --rm -i \
+		-e BUILD_CONFIG="$(BUILD_CONFIG)" \
+		-e PACKAGES_DIR_OPT="-packagesdir $(SEGGER_DIR)/packages" \
+		-e SEGGER_DIR="$(SEGGER_DIR)" \
+		-v $(PWD):/dotbot $(DOCKER_IMAGE) \
+		make $(DOCKER_TARGETS)


### PR DESCRIPTION
This pull-request is two-fold:
- it reworks the original github actions build workflow in a way that it can be used on a GitHub shared runner instead of the no longer existing self-hosted runner. The build command is launched within the Docker image used by https://github.com/DotBots/DotBot-firmware CI. The Makefile is adapted for this repository. The build job builds in both Debug and Release configurations. Another change in the workflow is the removal of `02drv_triangle` artifacts that don't/no longer exist in the main branch.
- while testing the Docker command locally, some build issues were raised. This is because of some recent update of the _ntw_ API that were adapted to all related applications (in 83beccd1588f60e10c9430800dbc4fdf1214fe54). 1315e8346743204a02c0eb7575ee00880fec839a set `NULL` arguments for the missing function pointer but I believe a more proper fix is needed.

Fixes #75